### PR TITLE
Split standard specific mapping stuff apart from plain normalization

### DIFF
--- a/src/Mapping/EmbeddedNormalizationObjectMapping.php
+++ b/src/Mapping/EmbeddedNormalizationObjectMapping.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Chubbyphp\Serialization\Mapping;
+
+interface EmbeddedNormalizationObjectMapping
+{
+    /**
+     * @param string $path
+     *
+     * @return NormalizationFieldMappingInterface[]
+     */
+    public function getNormalizationEmbeddedFieldMappings(string $path): array;
+}

--- a/src/Mapping/LegacyNormalizationObjectMappingInterface.php
+++ b/src/Mapping/LegacyNormalizationObjectMappingInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Chubbyphp\Serialization\Mapping;
+
+interface LegacyNormalizationObjectMappingInterface extends NormalizationObjectMappingInterface, EmbeddedNormalizationObjectMapping, LinkNormalizationObjectMapping, TypeNormalizationObjectMapping {
+
+}

--- a/src/Mapping/LinkNormalizationObjectMapping.php
+++ b/src/Mapping/LinkNormalizationObjectMapping.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Chubbyphp\Serialization\Mapping;
+
+interface LinkNormalizationObjectMapping
+{
+    /**
+     * @param string $path
+     *
+     * @return NormalizationLinkMappingInterface[]
+     */
+    public function getNormalizationLinkMappings(string $path): array;
+}

--- a/src/Mapping/NormalizationObjectMappingInterface.php
+++ b/src/Mapping/NormalizationObjectMappingInterface.php
@@ -22,18 +22,4 @@ interface NormalizationObjectMappingInterface
      * @return NormalizationFieldMappingInterface[]
      */
     public function getNormalizationFieldMappings(string $path): array;
-
-    /**
-     * @param string $path
-     *
-     * @return NormalizationFieldMappingInterface[]
-     */
-    public function getNormalizationEmbeddedFieldMappings(string $path): array;
-
-    /**
-     * @param string $path
-     *
-     * @return NormalizationLinkMappingInterface[]
-     */
-    public function getNormalizationLinkMappings(string $path): array;
 }

--- a/src/Mapping/TypeNormalizationObjectMapping.php
+++ b/src/Mapping/TypeNormalizationObjectMapping.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Chubbyphp\Serialization\Mapping;
+
+interface TypeNormalizationObjectMapping
+{
+    /**
+     * @return string
+     */
+    public function getNormalizationType(): string;
+}

--- a/src/Normalizer/Normalizer.php
+++ b/src/Normalizer/Normalizer.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Chubbyphp\Serialization\Normalizer;
 
+use Chubbyphp\Serialization\Mapping\EmbeddedNormalizationObjectMapping;
+use Chubbyphp\Serialization\Mapping\LinkNormalizationObjectMapping;
 use Chubbyphp\Serialization\Mapping\NormalizationFieldMappingInterface;
 use Chubbyphp\Serialization\Mapping\NormalizationLinkMappingInterface;
 use Chubbyphp\Serialization\Mapping\NormalizationObjectMappingInterface;
+use Chubbyphp\Serialization\Mapping\TypeNormalizationObjectMapping;
 use Chubbyphp\Serialization\SerializerLogicException;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -58,21 +61,27 @@ final class Normalizer implements NormalizerInterface
 
         $data = $this->getFieldsByFieldNormalizationMappings($context, $fieldMappings, $path, $object);
 
-        $embeddedMappings = $objectMapping->getNormalizationEmbeddedFieldMappings($path);
-        $embedded = $this->getFieldsByFieldNormalizationMappings($context, $embeddedMappings, $path, $object);
+        if ($objectMapping instanceof EmbeddedNormalizationObjectMapping) {
+            $embeddedMappings = $objectMapping->getNormalizationEmbeddedFieldMappings($path);
+            $embedded = $this->getFieldsByFieldNormalizationMappings($context, $embeddedMappings, $path, $object);
 
-        $linkMappings = $objectMapping->getNormalizationLinkMappings($path);
-        $links = $this->getLinksByLinkNormalizationMappings($context, $linkMappings, $path, $object);
-
-        if ([] !== $embedded) {
-            $data['_embedded'] = $embedded;
+            if ([] !== $embedded) {
+                $data['_embedded'] = $embedded;
+            }
         }
 
-        if ([] !== $links) {
-            $data['_links'] = $links;
+        if ($objectMapping instanceof LinkNormalizationObjectMapping) {
+            $linkMappings = $objectMapping->getNormalizationLinkMappings($path);
+            $links = $this->getLinksByLinkNormalizationMappings($context, $linkMappings, $path, $object);
+
+            if ([] !== $links) {
+                $data['_links'] = $links;
+            }
         }
 
-        $data['_type'] = $objectMapping->getNormalizationType();
+        if ($objectMapping instanceof TypeNormalizationObjectMapping) {
+            $data['_type'] = $objectMapping->getNormalizationType();
+        }
 
         return $data;
     }

--- a/tests/DependencyInjection/SerializationCompilerPassTest.php
+++ b/tests/DependencyInjection/SerializationCompilerPassTest.php
@@ -8,7 +8,7 @@ use Chubbyphp\Serialization\DependencyInjection\SerializationCompilerPass;
 use Chubbyphp\Serialization\Encoder\Encoder;
 use Chubbyphp\Serialization\Mapping\NormalizationFieldMappingInterface;
 use Chubbyphp\Serialization\Mapping\NormalizationLinkMappingInterface;
-use Chubbyphp\Serialization\Mapping\NormalizationObjectMappingInterface;
+use Chubbyphp\Serialization\Mapping\LegacyNormalizationObjectMappingInterface;
 use Chubbyphp\Serialization\Normalizer\Normalizer;
 use Chubbyphp\Serialization\Normalizer\NormalizerObjectMappingRegistry;
 use Chubbyphp\Serialization\Serializer;
@@ -70,7 +70,7 @@ class SerializationCompilerPassTest extends TestCase
 
     private function getStdClassMapping()
     {
-        return new class() implements NormalizationObjectMappingInterface {
+        return new class() implements LegacyNormalizationObjectMappingInterface {
             /**
              * @return string
              */

--- a/tests/Mapping/CallableNormalizationObjectMappingTest.php
+++ b/tests/Mapping/CallableNormalizationObjectMappingTest.php
@@ -6,7 +6,7 @@ namespace Chubbyphp\Tests\Serialization\Mapping;
 
 use Chubbyphp\Serialization\Mapping\CallableNormalizationObjectMapping;
 use Chubbyphp\Serialization\Mapping\NormalizationFieldMappingInterface;
-use Chubbyphp\Serialization\Mapping\NormalizationObjectMappingInterface;
+use Chubbyphp\Serialization\Mapping\LegacyNormalizationObjectMappingInterface;
 use Chubbyphp\Mock\Call;
 use Chubbyphp\Mock\MockByCallsTrait;
 use PHPUnit\Framework\TestCase;
@@ -29,7 +29,7 @@ class CallableNormalizationObjectMappingTest extends TestCase
     public function testGetNormalizationType()
     {
         $mapping = new CallableNormalizationObjectMapping(\stdClass::class, function () {
-            return $this->getMockByCalls(NormalizationObjectMappingInterface::class, [
+            return $this->getMockByCalls(LegacyNormalizationObjectMappingInterface::class, [
                 Call::create('getNormalizationType')->with()->willReturn('type'),
             ]);
         });
@@ -42,7 +42,7 @@ class CallableNormalizationObjectMappingTest extends TestCase
         $fieldMapping = $this->getMockByCalls(NormalizationFieldMappingInterface::class);
 
         $mapping = new CallableNormalizationObjectMapping(\stdClass::class, function () use ($fieldMapping) {
-            return $this->getMockByCalls(NormalizationObjectMappingInterface::class, [
+            return $this->getMockByCalls(LegacyNormalizationObjectMappingInterface::class, [
                 Call::create('getNormalizationFieldMappings')->with('path')->willReturn([$fieldMapping]),
             ]);
         });
@@ -55,7 +55,7 @@ class CallableNormalizationObjectMappingTest extends TestCase
         $fieldMapping = $this->getMockByCalls(NormalizationFieldMappingInterface::class);
 
         $mapping = new CallableNormalizationObjectMapping(\stdClass::class, function () use ($fieldMapping) {
-            return $this->getMockByCalls(NormalizationObjectMappingInterface::class, [
+            return $this->getMockByCalls(LegacyNormalizationObjectMappingInterface::class, [
                 Call::create('getNormalizationEmbeddedFieldMappings')->with('path')->willReturn([$fieldMapping]),
             ]);
         });
@@ -68,7 +68,7 @@ class CallableNormalizationObjectMappingTest extends TestCase
         $linkMapping = $this->getMockByCalls(NormalizationLinkMappingInterface::class);
 
         $mapping = new CallableNormalizationObjectMapping(\stdClass::class, function () use ($linkMapping) {
-            return $this->getMockByCalls(NormalizationObjectMappingInterface::class, [
+            return $this->getMockByCalls(LegacyNormalizationObjectMappingInterface::class, [
                 Call::create('getNormalizationLinkMappings')->with('path')->willReturn([$linkMapping]),
             ]);
         });

--- a/tests/Mapping/LazyNormalizationObjectMappingTest.php
+++ b/tests/Mapping/LazyNormalizationObjectMappingTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Chubbyphp\Tests\Serialization\Mapping;
 
 use Chubbyphp\Serialization\Mapping\NormalizationFieldMappingInterface;
-use Chubbyphp\Serialization\Mapping\NormalizationObjectMappingInterface;
+use Chubbyphp\Serialization\Mapping\LegacyNormalizationObjectMappingInterface;
 use Chubbyphp\Serialization\Mapping\LazyNormalizationObjectMapping;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -67,17 +67,17 @@ class LazyNormalizationObjectMappingTest extends TestCase
      * @param array  $normalizationEmbeddedFieldMappings
      * @param array  $normalizationLinkMappings
      *
-     * @return NormalizationObjectMappingInterface
+     * @return LegacyNormalizationObjectMappingInterface
      */
     private function getNormalizationObjectMapping(
         string $normalizationType,
         array $normalizationFieldMappings,
         array $normalizationEmbeddedFieldMappings,
         array $normalizationLinkMappings
-    ): NormalizationObjectMappingInterface {
-        /** @var NormalizationObjectMappingInterface|\PHPUnit_Framework_MockObject_MockObject $mapping */
+    ): LegacyNormalizationObjectMappingInterface {
+        /** @var LegacyNormalizationObjectMappingInterface|\PHPUnit_Framework_MockObject_MockObject $mapping */
         $mapping = $this
-            ->getMockBuilder(NormalizationObjectMappingInterface::class)
+            ->getMockBuilder(LegacyNormalizationObjectMappingInterface::class)
             ->setMethods([
                 'getNormalizationType',
                 'getNormalizationFieldMappings',

--- a/tests/Normalizer/NormalizerObjectMappingRegistryTest.php
+++ b/tests/Normalizer/NormalizerObjectMappingRegistryTest.php
@@ -6,7 +6,7 @@ namespace Chubbyphp\Tests\Serialization\Normalizer;
 
 use Chubbyphp\Serialization\Normalizer\NormalizerObjectMappingRegistry;
 use Chubbyphp\Serialization\SerializerLogicException;
-use Chubbyphp\Serialization\Mapping\NormalizationObjectMappingInterface;
+use Chubbyphp\Serialization\Mapping\LegacyNormalizationObjectMappingInterface;
 use Chubbyphp\Tests\Serialization\Resources\Model\AbstractManyModel;
 use Doctrine\Common\Persistence\Proxy;
 use PHPUnit\Framework\TestCase;
@@ -26,7 +26,7 @@ class NormalizerObjectMappingRegistryTest extends TestCase
 
         $mapping = $registry->getObjectMapping(get_class($object));
 
-        self::assertInstanceOf(NormalizationObjectMappingInterface::class, $mapping);
+        self::assertInstanceOf(LegacyNormalizationObjectMappingInterface::class, $mapping);
     }
 
     public function testGetMissingObjectMapping()
@@ -49,16 +49,16 @@ class NormalizerObjectMappingRegistryTest extends TestCase
 
         $mapping = $registry->getObjectMapping(get_class($object));
 
-        self::assertInstanceOf(NormalizationObjectMappingInterface::class, $mapping);
+        self::assertInstanceOf(LegacyNormalizationObjectMappingInterface::class, $mapping);
     }
 
     /**
-     * @return NormalizationObjectMappingInterface
+     * @return LegacyNormalizationObjectMappingInterface
      */
-    private function getNormalizationObjectMapping(): NormalizationObjectMappingInterface
+    private function getNormalizationObjectMapping(): LegacyNormalizationObjectMappingInterface
     {
-        /** @var NormalizationObjectMappingInterface|\PHPUnit_Framework_MockObject_MockObject $objectMapping */
-        $objectMapping = $this->getMockBuilder(NormalizationObjectMappingInterface::class)
+        /** @var LegacyNormalizationObjectMappingInterface|\PHPUnit_Framework_MockObject_MockObject $objectMapping */
+        $objectMapping = $this->getMockBuilder(LegacyNormalizationObjectMappingInterface::class)
             ->setMethods([])
             ->getMockForAbstractClass();
 
@@ -74,12 +74,12 @@ class NormalizerObjectMappingRegistryTest extends TestCase
     }
 
     /**
-     * @return NormalizationObjectMappingInterface
+     * @return LegacyNormalizationObjectMappingInterface
      */
-    private function getNormalizationProxyObjectMapping(): NormalizationObjectMappingInterface
+    private function getNormalizationProxyObjectMapping(): LegacyNormalizationObjectMappingInterface
     {
-        /** @var NormalizationObjectMappingInterface|\PHPUnit_Framework_MockObject_MockObject $objectMapping */
-        $objectMapping = $this->getMockBuilder(NormalizationObjectMappingInterface::class)
+        /** @var LegacyNormalizationObjectMappingInterface|\PHPUnit_Framework_MockObject_MockObject $objectMapping */
+        $objectMapping = $this->getMockBuilder(LegacyNormalizationObjectMappingInterface::class)
             ->setMethods([])
             ->getMockForAbstractClass();
 

--- a/tests/Normalizer/NormalizerTest.php
+++ b/tests/Normalizer/NormalizerTest.php
@@ -6,7 +6,7 @@ namespace Chubbyphp\Tests\Serialization\Normalizer;
 
 use Chubbyphp\Serialization\Mapping\NormalizationFieldMappingInterface;
 use Chubbyphp\Serialization\Mapping\NormalizationLinkMappingInterface;
-use Chubbyphp\Serialization\Mapping\NormalizationObjectMappingInterface;
+use Chubbyphp\Serialization\Mapping\LegacyNormalizationObjectMappingInterface;
 use Chubbyphp\Serialization\Normalizer\FieldNormalizerInterface;
 use Chubbyphp\Serialization\Normalizer\LinkNormalizerInterface;
 use Chubbyphp\Serialization\Normalizer\Normalizer;
@@ -144,16 +144,16 @@ class NormalizerTest extends TestCase
      * @param array $groupLinks
      * @param bool  $nullLink
      *
-     * @return NormalizationObjectMappingInterface
+     * @return LegacyNormalizationObjectMappingInterface
      */
     private function getNormalizationObjectMapping(
         array $groupFields = [],
         array $groupEmbeddedFields = [],
         array $groupLinks = [],
         bool $nullLink = false
-    ): NormalizationObjectMappingInterface {
+    ): LegacyNormalizationObjectMappingInterface {
         /** @var NormalizationObjectMappingInterface|\PHPUnit_Framework_MockObject_MockObject $objectMapping */
-        $objectMapping = $this->getMockBuilder(NormalizationObjectMappingInterface::class)
+        $objectMapping = $this->getMockBuilder(LegacyNormalizationObjectMappingInterface::class)
             ->setMethods([])
             ->getMockForAbstractClass();
 

--- a/tests/Resources/Mapping/ManyModelMapping.php
+++ b/tests/Resources/Mapping/ManyModelMapping.php
@@ -7,10 +7,10 @@ namespace Chubbyphp\Tests\Serialization\Resources\Mapping;
 use Chubbyphp\Serialization\Mapping\NormalizationLinkMappingInterface;
 use Chubbyphp\Serialization\Mapping\NormalizationFieldMappingBuilder;
 use Chubbyphp\Serialization\Mapping\NormalizationFieldMappingInterface;
-use Chubbyphp\Serialization\Mapping\NormalizationObjectMappingInterface;
+use Chubbyphp\Serialization\Mapping\LegacyNormalizationObjectMappingInterface;
 use Chubbyphp\Tests\Serialization\Resources\Model\ManyModel;
 
-final class ManyModelMapping implements NormalizationObjectMappingInterface
+final class ManyModelMapping implements LegacyNormalizationObjectMappingInterface
 {
     /**
      * @return string

--- a/tests/Resources/Mapping/ModelMapping.php
+++ b/tests/Resources/Mapping/ModelMapping.php
@@ -10,10 +10,10 @@ use Chubbyphp\Serialization\Mapping\NormalizationLinkMappingInterface;
 use Chubbyphp\Serialization\Normalizer\CallbackLinkNormalizer;
 use Chubbyphp\Serialization\Mapping\NormalizationFieldMappingBuilder;
 use Chubbyphp\Serialization\Mapping\NormalizationFieldMappingInterface;
-use Chubbyphp\Serialization\Mapping\NormalizationObjectMappingInterface;
+use Chubbyphp\Serialization\Mapping\LegacyNormalizationObjectMappingInterface;
 use Chubbyphp\Tests\Serialization\Resources\Model\Model;
 
-final class ModelMapping implements NormalizationObjectMappingInterface
+final class ModelMapping implements LegacyNormalizationObjectMappingInterface
 {
     /**
      * @return string

--- a/tests/Resources/Mapping/OneModelMapping.php
+++ b/tests/Resources/Mapping/OneModelMapping.php
@@ -7,10 +7,10 @@ namespace Chubbyphp\Tests\Serialization\Resources\Mapping;
 use Chubbyphp\Serialization\Mapping\NormalizationLinkMappingInterface;
 use Chubbyphp\Serialization\Mapping\NormalizationFieldMappingBuilder;
 use Chubbyphp\Serialization\Mapping\NormalizationFieldMappingInterface;
-use Chubbyphp\Serialization\Mapping\NormalizationObjectMappingInterface;
+use Chubbyphp\Serialization\Mapping\LegacyNormalizationObjectMappingInterface;
 use Chubbyphp\Tests\Serialization\Resources\Model\OneModel;
 
-final class OneModelMapping implements NormalizationObjectMappingInterface
+final class OneModelMapping implements LegacyNormalizationObjectMappingInterface
 {
     /**
      * @return string


### PR DESCRIPTION
If I want to serialize something which does not have a  `_type` field I can't do this with the current Normalizer. This PR aims to split standard specific normalization tasks apart and let me serialize stuff the way I want.

This is a big BC... so maybe for next major. Any thoughts?