### PR TITLE
Fix type hinting

### DIFF
--- a/src/Mapping/CallableNormalizationObjectMapping.php
+++ b/src/Mapping/CallableNormalizationObjectMapping.php
@@ -40,9 +40,9 @@ final class CallableNormalizationObjectMapping implements NormalizationObjectMap
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getNormalizationType(): string
+    public function getNormalizationType()
     {
         return $this->getMapping()->getNormalizationType();
     }


### PR DESCRIPTION
There was still a type hinting in place for the `CallableNormalizationObjectMapping` class. I removed it to make it fully compatible with the interface.