### PR TITLE
fix-phpdoc-method-structure

### DIFF
--- a/src/Mapping/NormalizationFieldMappingBuilderInterface.php
+++ b/src/Mapping/NormalizationFieldMappingBuilderInterface.php
@@ -8,7 +8,7 @@ use Chubbyphp\Serialization\Normalizer\FieldNormalizerInterface;
 use Chubbyphp\Serialization\Policy\PolicyInterface;
 
 /**
- * @method setPolicy(PolicyInterface $policy): self
+ * @method NormalizationFieldMappingBuilderInterface setPolicy(PolicyInterface $policy)
  */
 interface NormalizationFieldMappingBuilderInterface
 {

--- a/src/Mapping/NormalizationFieldMappingInterface.php
+++ b/src/Mapping/NormalizationFieldMappingInterface.php
@@ -8,7 +8,7 @@ use Chubbyphp\Serialization\Normalizer\FieldNormalizerInterface;
 use Chubbyphp\Serialization\Policy\PolicyInterface;
 
 /**
- * @method getPolicy(): PolicyInterface
+ * @method PolicyInterface getPolicy()
  */
 interface NormalizationFieldMappingInterface
 {

--- a/src/Mapping/NormalizationLinkMappingBuilderInterface.php
+++ b/src/Mapping/NormalizationLinkMappingBuilderInterface.php
@@ -8,7 +8,7 @@ use Chubbyphp\Serialization\Normalizer\LinkNormalizerInterface;
 use Chubbyphp\Serialization\Policy\PolicyInterface;
 
 /**
- * @method setPolicy(PolicyInterface $policy): self
+ * @method NormalizationLinkMappingBuilderInterface setPolicy(PolicyInterface $policy)
  */
 interface NormalizationLinkMappingBuilderInterface
 {

--- a/src/Mapping/NormalizationLinkMappingInterface.php
+++ b/src/Mapping/NormalizationLinkMappingInterface.php
@@ -8,7 +8,7 @@ use Chubbyphp\Serialization\Normalizer\LinkNormalizerInterface;
 use Chubbyphp\Serialization\Policy\PolicyInterface;
 
 /**
- * @method getPolicy(): PolicyInterface
+ * @method PolicyInterface getPolicy()
  */
 interface NormalizationLinkMappingInterface
 {

--- a/src/Normalizer/NormalizerContextBuilderInterface.php
+++ b/src/Normalizer/NormalizerContextBuilderInterface.php
@@ -7,7 +7,7 @@ namespace Chubbyphp\Serialization\Normalizer;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
- * @method setAttributes(array $attributes): self
+ * @method NormalizerContextBuilderInterface setAttributes(array $attributes)
  */
 interface NormalizerContextBuilderInterface
 {

--- a/src/Normalizer/NormalizerContextInterface.php
+++ b/src/Normalizer/NormalizerContextInterface.php
@@ -7,9 +7,9 @@ namespace Chubbyphp\Serialization\Normalizer;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
- * @method getAttributes(): array
- * @method getAttribute(string $name, $default = null)
- * @method withAttribute(string $name, $value): self
+ * @method array                      getAttributes()
+ * @method mixed                      getAttribute(string $name, $default = null)
+ * @method NormalizerContextInterface withAttribute(string $name, $value)
  */
 interface NormalizerContextInterface
 {


### PR DESCRIPTION
Changelog:
- the PHPDoc ```@method``` structure has the return type before the method name - therefor this is now adjusted here
- fix some PHPDoc issues